### PR TITLE
cambio de nombre de variables en errorCheckbox

### DIFF
--- a/scripts/validacionFormulario.js
+++ b/scripts/validacionFormulario.js
@@ -89,10 +89,10 @@ class ValidacionFormulario{
     }
 
     errorCheckbox(idCampoCheckbox) {
-        const campoEmail = this.formulario.formulario.querySelector('#' + idCampoCheckbox);
-        let valorEmail = campoEmail.checked;
+        const campoCheckbox = this.formulario.formulario.querySelector('#' + idCampoCheckbox);
+        let valorCheckbox = campoCheckbox.checked;
 
-        if (!valorEmail) {
+        if (!valorCheckbox) {
             this.mostrarError("error-" + idCampoCheckbox, "Debes aceptar los terminos y condiciones", "#custom-checkbox-" + idCampoCheckbox);
             return true;
         }


### PR DESCRIPTION
En la funcion errorCheckbox de la clase ValidacionFormulario, las variables tenian nombres erroneos